### PR TITLE
Crafting menu fix.

### DIFF
--- a/tgui/packages/tgui/interfaces/Stack.jsx
+++ b/tgui/packages/tgui/interfaces/Stack.jsx
@@ -1,16 +1,8 @@
-import { sortBy } from 'common/collections';
 import { createSearch } from 'common/string';
 
 import { useBackend, useLocalState } from '../backend';
-import {
-  Box,
-  Button,
-  Collapsible,
-  Input,
-  NoticeBox,
-  Section,
-  Table,
-} from '../components';
+import { Box, Button, Input, NoticeBox, Section, Table } from '../components';
+import { Collapsible } from '../components';
 import { Window } from '../layouts';
 
 export const Stack = (props) => {
@@ -67,6 +59,27 @@ const RecipeList = (props) => {
 
   const { recipes } = props;
 
+  if (recipes.keys <= 0) return null;
+
+  let out = [];
+
+  for (let key in recipes) {
+    if (recipes[key].ref === undefined) {
+      out.push(
+        <Collapsible ml={1} color="label" title={key}>
+          <Box ml={1}>
+            <RecipeList recipes={recipes[key]} />
+          </Box>
+        </Collapsible>,
+      );
+    } else {
+      out.push(<Recipe title={key} recipe={recipes[key]} />);
+    }
+  }
+
+  return out;
+
+  /*
   const sortedKeys = sortBy((key) => key.toLowerCase())(Object.keys(recipes));
 
   return sortedKeys.map((title) => {
@@ -83,6 +96,7 @@ const RecipeList = (props) => {
       return <Recipe title={title} recipe={recipe} />;
     }
   });
+  */
 };
 
 const buildMultiplier = (recipe, amount) => {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug where the crafting menu threw errors when opened instead of working.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It lets you actually craft.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vrell
fix: makes the crafting menu functional.
refactor: the current code doesn't sort crafting lists alphabetically anymore. you can use this and sort them manually by what logically pairs in their list definitions or you can ping me on discord to implement alphabetical sort for you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
