### PR TITLE
Purged Player Voice Sounds

### DIFF
--- a/mojave/code/datums/components/mumbleboops.dm
+++ b/mojave/code/datums/components/mumbleboops.dm
@@ -32,6 +32,7 @@
 	INVOKE_ASYNC(src, PROC_REF(handle_booping), mumblebooper, speech_args, speech_spans, speech_mods)
 
 /datum/component/mumbleboop/proc/handle_booping(mob/living/mumblebooper, list/speech_args, list/speech_spans, list/speech_mods)
+	/* Vrell - Purge as requested by Blutz
 	chosen_boop = mumblebooper?.voice_type || random_voice_type(mumblebooper?.gender) // Uses the boop chosen by the player. If it's null for whatever unholy reason, it should chose a completely random voice for every single phonetic which should be funny.
 	var/message = speech_args[SPEECH_MESSAGE]
 	var/initial_mumbleboop_time = last_mumbleboop
@@ -135,11 +136,14 @@
 		final_boop = "mojave/sound/voices/[chosen_boop]/s_[boop_letter].wav"
 		addtimer(CALLBACK(src, PROC_REF(play_mumbleboop), hearers, mumblebooper, final_boop, volume, initial_mumbleboop_time, falloff_exponent), mumbleboop_delay_cumulative + current_delay)
 		mumbleboop_delay_cumulative += current_delay
+	*/
 
 /datum/component/mumbleboop/proc/play_mumbleboop(list/hearers, mob/mumblebooper, final_boop, volume, initial_mumbleboop_time, falloff_exponent)
+	/* Vrell - Purge as requested by Blutz
 	if(!volume || (last_mumbleboop != initial_mumbleboop_time))
 		return
 	for(var/mob/hearer as anything in hearers)
 		hearer.playsound_local(get_turf(mumblebooper), final_boop, volume, FALSE, falloff_exponent, max_distance = 16)
+	*/
 
 #undef MAX_MUMBLEBOOP_CHARACTERS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the text to speech thing Mojave Sun put in.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Requested by Blutz as a stop gap since this is very disturbing apparently. "It sounds like a wendigo ripped my friend's throat out and is playing it like a flute."

I for one enjoy the sounds but hey I'm just here to write the code not determine what is wrote.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vrell
fix: Removed sounds when players talk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
