### PR TITLE
Storm Fix + removed the understaffed message.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -529,9 +529,10 @@ SUBSYSTEM_DEF(job)
 	if(player_client)
 		if(job.req_admin_notify)
 			to_chat(player_client, "<span class='infoplain'><b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b></span>")
+		/* Vrell - Commenting out for now. Might have an alternative thing later? IDK
 		if(CONFIG_GET(number/minimal_access_threshold))
 			to_chat(player_client, span_notice("<B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B>"))
-
+		*/
 		var/related_policy = get_policy(job.title)
 		if(related_policy)
 			to_chat(player_client, related_policy)

--- a/mojave/code/modules/mob/living/emote.dm
+++ b/mojave/code/modules/mob/living/emote.dm
@@ -33,7 +33,7 @@
 		alived.weather_blindness_amount = 0
 		return ..()
 
-	var/amount_to_wipe = 50 < alived.weather_blindness_amount ? 50 : alived.weather_blindness_amount
+	var/amount_to_wipe = STORM_MAXIMUM_BLINDNESS / 2 < alived.weather_blindness_amount ? STORM_MAXIMUM_BLINDNESS / 2 : alived.weather_blindness_amount
 	alived.weather_blindness_amount -= amount_to_wipe
 	alived.adjust_blurriness(-amount_to_wipe)
 	message = "wipes their eyes."

--- a/mojave/code/modules/mob/living/emote.dm
+++ b/mojave/code/modules/mob/living/emote.dm
@@ -22,17 +22,22 @@
 	cooldown = 3.5 SECONDS
 
 /datum/emote/living/wipe/run_emote(mob/user, params, type_override, intentional)
+	if(!istype(user, /mob/living)) return //Vrell - storm logic doesn't work right on non-carbon mobs anyway
+	var/mob/living/alived = user
+
 	// If they're wearing a gas mask, it's implied they're wiping the mask. Easier to wipe a mask clean rather than your eyes!
 	if(HAS_TRAIT(user, TRAIT_WEARING_GAS_MASK))
 		message = "wipes their mask."
-		playsound(user.loc, 'mojave/sound/ms13effects/gasmask_wipe.ogg', 1, TRUE)
-		user.adjust_blurriness(-30)
+		playsound(alived.loc, 'mojave/sound/ms13effects/gasmask_wipe.ogg', 1, TRUE)
+		alived.adjust_blurriness(-alived.weather_blindness_amount)
+		alived.weather_blindness_amount = 0
 		return ..()
 
-	if(!HAS_TRAIT(user, TRAIT_WEARING_GAS_MASK))
-		user.adjust_blurriness(-10)
-		message = "wipes their eyes."
-		return ..()
+	var/amount_to_wipe = 50 < alived.weather_blindness_amount ? 50 : alived.weather_blindness_amount
+	alived.weather_blindness_amount -= amount_to_wipe
+	alived.adjust_blurriness(-amount_to_wipe)
+	message = "wipes their eyes."
+	return ..()
 
 // AGONY emote - Express that delicious pain!
 /datum/emote/living/agony

--- a/mojave/modules/outdoor_effects/code/datums/particle_weather/Datums/weather_datum_types.dm
+++ b/mojave/modules/outdoor_effects/code/datums/particle_weather/Datums/weather_datum_types.dm
@@ -1,3 +1,8 @@
+//Vrell - due to implementation concerns with the wipe emote, this is a global define.
+#define STORM_MAXIMUM_BLINDNESS 100
+
+/mob/living
+	var/weather_blindness_amount = 0
 
 /datum/particle_weather/dust_storm
 	name = "dust storm"
@@ -15,13 +20,19 @@
 	immunity_type = TRAIT_DUSTSTORM_IMMUNE
 	probability = 40
 	target_trait = PARTICLEWEATHER_DUST
+	var/storm_blindness_per_tick = 6.5
 
 /datum/particle_weather/dust_storm/weather_act(mob/living/carbon/L)
 	if(HAS_TRAIT(L, TRAIT_WEARING_GAS_MASK))
 		return
 
 	if(ishuman(L) && !L.is_eyes_covered())
-		L.adjust_blurriness(6.5)
+		if(L.weather_blindness_amount <= (STORM_MAXIMUM_BLINDNESS - storm_blindness_per_tick))
+			L.weather_blindness_amount += storm_blindness_per_tick
+			L.adjust_blurriness(storm_blindness_per_tick)
+		else
+			L.adjust_blurriness(STORM_MAXIMUM_BLINDNESS - L.weather_blindness_amount)
+			L.weather_blindness_amount = STORM_MAXIMUM_BLINDNESS
 
 /datum/particle_weather/radiation_storm
 	name = "radiation storm"
@@ -76,10 +87,16 @@
 	immunity_type = TRAIT_RAINSTORM_IMMUNE
 	probability = 5
 	target_trait = PARTICLEWEATHER_RAIN
+	var/storm_blindness_per_tick = 1
 
 /datum/particle_weather/rain_gentle/weather_act(mob/living/L)
 	if(HAS_TRAIT(L, TRAIT_WEARING_GAS_MASK))
-		L.adjust_blurriness(1)
+		if(L.weather_blindness_amount <= (STORM_MAXIMUM_BLINDNESS - storm_blindness_per_tick))
+			L.weather_blindness_amount += storm_blindness_per_tick
+			L.adjust_blurriness(storm_blindness_per_tick)
+		else
+			L.adjust_blurriness(STORM_MAXIMUM_BLINDNESS - L.weather_blindness_amount)
+			L.weather_blindness_amount = STORM_MAXIMUM_BLINDNESS
 		if(prob(10))
 			to_chat(L, "The [src] obscures your gas mask!")
 		return
@@ -100,10 +117,16 @@
 	immunity_type = TRAIT_RAINSTORM_IMMUNE
 	probability = 0
 	target_trait = PARTICLEWEATHER_RAIN
+	var/storm_blindness_per_tick = 1
 
 /datum/particle_weather/rain_storm/weather_act(mob/living/L)
 	if(HAS_TRAIT(L, TRAIT_WEARING_GAS_MASK))
-		L.adjust_blurriness(1.5)
+		if(L.weather_blindness_amount <= (STORM_MAXIMUM_BLINDNESS - storm_blindness_per_tick))
+			L.weather_blindness_amount += storm_blindness_per_tick
+			L.adjust_blurriness(storm_blindness_per_tick)
+		else
+			L.adjust_blurriness(STORM_MAXIMUM_BLINDNESS - L.weather_blindness_amount)
+			L.weather_blindness_amount = STORM_MAXIMUM_BLINDNESS
 		if(prob(10))
 			to_chat(L, "The [src] obscures your gas mask!")
 		return
@@ -124,10 +147,16 @@
 	immunity_type = TRAIT_SNOWSTORM_IMMUNE
 	probability = 1
 	target_trait = PARTICLEWEATHER_SNOW
+	var/storm_blindness_per_tick = 2.5
 
 /datum/particle_weather/snow_gentle/weather_act(mob/living/L)
 	if(HAS_TRAIT(L, TRAIT_WEARING_GAS_MASK))
-		L.adjust_blurriness(2.5)
+		if(L.weather_blindness_amount <= (STORM_MAXIMUM_BLINDNESS - storm_blindness_per_tick))
+			L.weather_blindness_amount += storm_blindness_per_tick
+			L.adjust_blurriness(storm_blindness_per_tick)
+		else
+			L.adjust_blurriness(STORM_MAXIMUM_BLINDNESS - L.weather_blindness_amount)
+			L.weather_blindness_amount = STORM_MAXIMUM_BLINDNESS
 		if(prob(10))
 			to_chat(L, "The [src] obscures your gas mask!")
 		return
@@ -148,15 +177,26 @@
 	immunity_type = TRAIT_SNOWSTORM_IMMUNE
 	probability = 1
 	target_trait = PARTICLEWEATHER_SNOW
+	var/storm_blindness_per_tick = 3.5
 
 //Makes you a lot little chilly
 /datum/particle_weather/snow_storm/weather_act(mob/living/L)
 	if(HAS_TRAIT(L, TRAIT_WEARING_GAS_MASK))
-		L.adjust_blurriness(3.5) // Snow sticks to your mask even worse than it gets into your mf eyes
+		if(L.weather_blindness_amount <= (STORM_MAXIMUM_BLINDNESS - storm_blindness_per_tick))
+			L.weather_blindness_amount += storm_blindness_per_tick
+			L.adjust_blurriness(storm_blindness_per_tick)
+		else
+			L.adjust_blurriness(STORM_MAXIMUM_BLINDNESS - L.weather_blindness_amount)
+			L.weather_blindness_amount = STORM_MAXIMUM_BLINDNESS
 		if(prob(10))
 			to_chat(L, "The [src] obscures your gas mask!")
 		return
 
 	if(ishuman(L) && !L.is_eyes_covered())
-		L.adjust_blurriness(2.5)
+		if(L.weather_blindness_amount <= (STORM_MAXIMUM_BLINDNESS - storm_blindness_per_tick))
+			L.weather_blindness_amount += storm_blindness_per_tick
+			L.adjust_blurriness(storm_blindness_per_tick)
+		else
+			L.adjust_blurriness(STORM_MAXIMUM_BLINDNESS - L.weather_blindness_amount)
+			L.weather_blindness_amount = STORM_MAXIMUM_BLINDNESS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Storm blindness no longer scales infinitely, and will always be wiped off within 2 wipes (1 for gas masks)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Request by Blutz. Makes the game actually playable durring a dust storm and make it possible to not be blind all game after a dust storm.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vrell
fix: comments out the line that causes the "this station is understaffed, you have extra access line" since it doesn't fit this game.
fix: capped the amount of blindness given by storms.
fix: makes the amount of blindness cured dependant on how much was given from storms.
fix: it is no longer possible to cure non-storm blindness by wiping your eyes.
code: the rate that blindness grows is now a variable on the storms that cause it and there is a global define for the maximum blindness storms can give.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
